### PR TITLE
Support `grunt-express`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ grunt.initConfig({
 })
 ```
 
+You may also optionally read rules from a different grunt config, like so:
+
+```js
+grunt.initConfig({
+    express: {
+        options: {
+            port: 9000
+        },
+        server: {
+            hostname: 'localhost'
+        },
+        rules: {
+            '^/index_dev.html$': '/src/index.html',
+            '^/js/(.*)$': '/src/js/$1',
+            '^/css/(.*)$': '/public/css/$1'
+        }
+    },
+    configureRewriteRules: {
+        options: {
+            rulesProvider: 'express.rules'
+        }
+    }
+}
+})
+```
+
 #### Adding the middleware
 Include helper to use in the middleware (add this line to the top of the grunt file):
 ```js

--- a/tasks/connect_rewrite.js
+++ b/tasks/connect_rewrite.js
@@ -12,7 +12,10 @@ var utils = require('../lib/utils');
 
 module.exports = function (grunt) {
     grunt.registerTask('configureRewriteRules', 'Configure connect rewriting rules.', function () {
-        var rules = grunt.config('connect.rules') || {};
+        var options = this.options({
+            rulesProvider: 'connect.rules'
+        });
+        var rules = grunt.config(options.rulesProvider) || {};
         Object.keys(rules).forEach(function (from) {
             var to = rules[from];
             if (utils.registerRule({from: from, to: to})) {


### PR DESCRIPTION
It'd be nice if we can allow the optional config `rulesProvider` to read from a different grunt config path other than `connect.rules`. So https://github.com/blai/grunt-express can also be supported (requested by `grunt-express` user).
