### PR TITLE
Middleware was missing the options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add the RewriteRules snippet to the connect option middleware hook
 connect: {
     development: {
         options: {
-            middleware: function (connect) {
+            middleware: function (connect, options) {
                 return [
                     rewriteRulesSnippet, // RewriteRules support
                     connect.static(require('path').resolve(options.base)) // mount filesystem


### PR DESCRIPTION
The current README shows a middleware configuration that does not work because the `options` parameter is missing.
