### PR TITLE
Sets the task as multitask

### DIFF
--- a/tasks/connect_rewrite.js
+++ b/tasks/connect_rewrite.js
@@ -11,7 +11,7 @@
 var utils = require('../lib/utils');
 
 module.exports = function (grunt) {
-    grunt.registerTask('configureRewriteRules', 'Configure connect rewriting rules.', function () {
+    grunt.registerMultiTask('configureRewriteRules', 'Configure connect rewriting rules.', function () {
         var options = this.options({
             rulesProvider: 'connect.rules'
         });


### PR DESCRIPTION
So it'll support:

```
configureRewriteRules: {
  app: {
    options: {
      rulesProvider: 'connect.app.rules'
    }
  },
  "static": {
    options: {
      rulesProvider: 'connect.static.rules'
    }
  }
}
```

then the tasks will be `configureRewriteRules:app` and `configureRewriteRules:static`
