### PR TITLE
write log messages when connect.options.debug = true. fixes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ grunt.registerTask('server', function (target) {
 });
 ```
 
+### Debugging rules
+
+Setting `debug: true` on `connect.options` will print `grunt.log` messages when rewrite happens. The message will explain which __from__ rule was matched and what was the result of the rewrite.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,6 +45,9 @@ utils.dispatcher = function (req, res, next) {
         var toUrl;
         if (rule.from.test(req.url)) {
             toUrl = req.url.replace(rule.from, rule.to);
+            if (utils.debugging) {
+                utils.log.ok('Request ' + req.url + ' matched rule ' + rule.from + '. Rewrote to ' + toUrl);
+            }
             if (!rule.redirect) {
                 req.url = toUrl;
                 next();

--- a/tasks/connect_rewrite.js
+++ b/tasks/connect_rewrite.js
@@ -15,6 +15,8 @@ module.exports = function (grunt) {
         var options = this.options({
             rulesProvider: 'connect.rules'
         });
+        utils.debugging = grunt.config('connect.options.debug');
+        utils.log = grunt.log;
         (grunt.config(options.rulesProvider) || []).forEach(function (rule) {
             rule = rule || {};
             var registeredRule = utils.registerRule({from: rule.from, to: rule.to, redirect: rule.redirect});

--- a/test/connect_rewrite_test.js
+++ b/test/connect_rewrite_test.js
@@ -129,5 +129,25 @@ exports.connect_rewrite = {
         test.equal(res.wasEnded, 0, 'Response should not be ended.');
 
         test.done();
+    },
+    testLogging: function (test) {
+        var req = {};
+        utils.log = {
+            wasCalled: false,
+            ok: function () {
+                this.wasCalled = true;
+            }
+        };
+        utils.debugging = true;
+        test.expect(1);
+
+        utils.registerRule({from: '^/fr[o0]m-([^-]+)-(\\d+)\\.html$', to: '/to-$1-$2.html'});
+
+        req.url = '/fr0m-s0me-123.html';
+        utils.rewriteRequest(req, res, function () { });
+
+        test.equal(utils.log.wasCalled, true);
+
+        test.done();
     }
 };


### PR DESCRIPTION
When `connect.options.debug = true`, the plugin will print log statements for each request that explain which rewrite rule matched the request and into what the request was transformed by that rewrite.
